### PR TITLE
demolearn-37[Feat]: 카테고리 토글 추가 및 커리큘럼 페이지 ui 수정

### DIFF
--- a/app/curriculum/page.tsx
+++ b/app/curriculum/page.tsx
@@ -5,19 +5,21 @@ import LecturesSidebar from "@/components/curriculum/LecturesSidebar";
 
 export default function LecturesPage() {
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-white">
       {/* Hero Section */}
       <LecturesHero />
 
       {/* Main Content with Sidebar */}
-      <div className="flex">
+      <div className="flex max-w-7xl mx-auto">
         {/* Left Sidebar */}
-        <LecturesSidebar />
+        <div className="w-64 flex-shrink-0">
+          <LecturesSidebar />
+        </div>
 
         {/* Main Content Area */}
-        <div className="flex-1 p-6">
+        <div className="flex-1 px-8 py-6">
           {/* Section Title and Filter */}
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between mb-8">
             <h2 className="text-2xl font-bold text-gray-900">오리지널</h2>
             <div className="flex items-center space-x-4">
               <select className="text-sm border border-gray-300 rounded-md px-3 py-2 bg-white focus:outline-none focus:ring-1 focus:ring-blue-500">

--- a/components/curriculum/LectureCard.tsx
+++ b/components/curriculum/LectureCard.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "@/components/ui/badge";
 import { Star, Heart } from "lucide-react";
 import Image from "next/image";
 import { Lecture } from "@/app/lecture/[id]/lectures";
@@ -9,7 +8,7 @@ interface LectureCardProps {
 
 export default function LectureCard({ lecture }: LectureCardProps) {
   return (
-    <div className="bg-white rounded-lg overflow-hidden shadow-sm">
+    <div className="bg-white rounded-lg overflow-hidden shadow-sm hover:shadow-md transition-shadow duration-200">
       {/* Thumbnail */}
       <div className="aspect-video relative bg-gray-200 overflow-hidden">
         <Image
@@ -20,32 +19,33 @@ export default function LectureCard({ lecture }: LectureCardProps) {
           className="object-cover"
         />
         {/* Heart Icon */}
-        <div className="absolute top-3 right-3">
-          <Heart className="h-6 w-6 text-white" />
+        <div className="absolute top-4 right-4">
+          <Heart className="h-7 w-7 text-white fill-white opacity-80 hover:opacity-100 transition-opacity cursor-pointer" />
         </div>
-        
-        {/* Badges */}
-        <div className="absolute bottom-3 left-3 flex space-x-2">
-          <Badge className="bg-black text-white text-xs font-bold">
-            ORIGINAL
-          </Badge>
-        </div>
+        {/* No badges */}
       </div>
 
       {/* Content */}
-      <div className="p-4">
+      <div className="p-5">
         {/* Title */}
-        <h3 className="font-medium text-gray-900 mb-2 text-sm leading-tight">
+        <h3 className="font-semibold text-gray-900 mb-3 text-base leading-snug line-clamp-2">
           {lecture.title}
         </h3>
 
         {/* Rating */}
         <div className="flex items-center mb-2">
-          <Star className="h-4 w-4 text-yellow-400 fill-current" />
-          <span className="ml-1 text-sm font-medium">{lecture.rating || '4.9'}</span>
-          <span className="ml-1 text-sm text-gray-500">
-            ({lecture.reviews || 483}) {lecture.category}
+          <Star className="h-5 w-5 text-yellow-400 fill-current" />
+          <span className="ml-2 text-base font-semibold text-gray-900">
+            {lecture.rating || '4.9'}
           </span>
+          <span className="ml-1 text-sm text-gray-500">
+            ({lecture.reviews || 483})
+          </span>
+        </div>
+
+        {/* Instructor and Category */}
+        <div className="text-sm text-gray-600">
+          {lecture.instructor.name} • {lecture.category}
         </div>
       </div>
     </div>

--- a/components/curriculum/LecturesGrid.tsx
+++ b/components/curriculum/LecturesGrid.tsx
@@ -7,7 +7,7 @@ interface LecturesGridProps {
 
 export default function LecturesGrid({ lectures }: LecturesGridProps) {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
       {lectures.map((lecture) => (
         <LectureCard key={lecture.id} lecture={lecture} />
       ))}

--- a/components/curriculum/LecturesHero.tsx
+++ b/components/curriculum/LecturesHero.tsx
@@ -18,22 +18,26 @@ export default function LecturesHero() {
             </div>
           </div>
           
-          {/* 오른쪽 이미지 영역 (실제 이미지가 없으므로 placeholder) */}
-          <div className="flex-shrink-0 ml-8">
-            <div className="flex space-x-4">
-              <div className="w-20 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
-                <span className="text-2xl">💻</span>
+          {/* 오른쪽 인물 이미지 영역 */}
+          <div className="flex-shrink-0 ml-8 flex items-center">
+            <div className="flex space-x-4 mr-8">
+              {/* 세 명의 인물을 나타내는 placeholder */}
+              <div className="w-16 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
+                <span className="text-2xl">👨‍💼</span>
               </div>
-              <div className="w-20 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
-                <span className="text-2xl">🚀</span>
+              <div className="w-16 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
+                <span className="text-2xl">👩‍💼</span>
               </div>
-              <div className="w-20 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
-                <span className="text-2xl">👩‍💻</span>
+              <div className="w-16 h-20 bg-white bg-opacity-20 rounded-full flex items-center justify-center">
+                <span className="text-2xl">👨‍💼</span>
               </div>
             </div>
-            <div className="mt-4 text-center">
-              <div className="bg-black text-white px-6 py-3 rounded-lg font-semibold">
-                지금 무료로 시작하기 →
+            <div className="text-center">
+              <div className="bg-black text-white px-6 py-3 rounded-lg font-semibold text-sm">
+                7.30(수) 오전11시
+              </div>
+              <div className="text-sm mt-1">
+                선착순 접수 →
               </div>
             </div>
           </div>

--- a/components/curriculum/LecturesSidebar.tsx
+++ b/components/curriculum/LecturesSidebar.tsx
@@ -3,59 +3,52 @@ export default function LecturesSidebar() {
   return (
     <div className="w-64 bg-white border-r border-gray-200 min-h-screen">
       <div className="p-6">
-        {/* 프론트엔드 섹션 */}
+        {/* 오리지널 섹션 */}
         <div className="mb-8">
           <div className="py-2">
-            <h3 className="text-lg font-semibold text-blue-600">프론트엔드</h3>
+            <h3 className="text-lg font-semibold text-blue-600">오리지널</h3>
           </div>
           <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">React</span></li>
-            <li><span className="text-gray-600">Vue.js</span></li>
-            <li><span className="text-gray-600">Next.js</span></li>
-            <li><span className="text-gray-600">TypeScript</span></li>
-            <li><span className="text-gray-600">UI/UX</span></li>
+            <li><span className="text-gray-600">바이브 빌더스</span></li>
           </ul>
         </div>
 
-        {/* 백엔드 섹션 */}
+        {/* 바이브 코딩 섹션 */}
         <div className="mb-8">
           <div className="py-2">
-            <h3 className="text-lg font-semibold">백엔드</h3>
+            <h3 className="text-lg font-semibold">바이브 코딩</h3>
           </div>
           <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">Node.js</span></li>
-            <li><span className="text-gray-600">Spring Boot</span></li>
-            <li><span className="text-gray-600">Django</span></li>
-            <li><span className="text-gray-600">Go</span></li>
-            <li><span className="text-gray-600">Database</span></li>
+            <li><span className="text-gray-600">프롬프트 엔지니어링</span></li>
+            <li><span className="text-gray-600">컨텍스트 엔지니어링</span></li>
+            <li><span className="text-gray-600">AI 도구 활용</span></li>
           </ul>
         </div>
 
-        {/* AI/머신러닝 섹션 */}
+        {/* 앱/웹 섹션 */}
         <div className="mb-8">
           <div className="py-2">
-            <h3 className="text-lg font-semibold">AI/머신러닝</h3>
+            <h3 className="text-lg font-semibold">앱/웹</h3>
           </div>
           <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">Python</span></li>
-            <li><span className="text-gray-600">TensorFlow</span></li>
+            <li><span className="text-gray-600">앱 바이브 코딩 입문</span></li>
+            <li><span className="text-gray-600">웹 바이브 코딩 입문</span></li>
+            <li><span className="text-gray-600">앱 수익화</span></li>
+            <li><span className="text-gray-600">웹 수익화</span></li>
+          </ul>
+        </div>
+
+        {/* 자동화 섹션 */}
+        <div className="mb-8">
+          <div className="py-2">
+            <h3 className="text-lg font-semibold">자동화</h3>
+          </div>
+          <ul className="mt-2 space-y-2 pl-4">
+            <li><span className="text-gray-600">n8n</span></li>
+            <li><span className="text-gray-600">Make</span></li>
             <li><span className="text-gray-600">PyTorch</span></li>
-            <li><span className="text-gray-600">데이터 분석</span></li>
-            <li><span className="text-gray-600">챗봇/LLM</span></li>
-          </ul>
-        </div>
-
-        {/* DevOps/클라우드 섹션 */}
-        <div className="mb-8">
-          <div className="py-2">
-            <h3 className="text-lg font-semibold">DevOps/클라우드</h3>
-          </div>
-          <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">AWS</span></li>
-            <li><span className="text-gray-600">Docker</span></li>
-            <li><span className="text-gray-600">Kubernetes</span></li>
-            <li><span className="text-gray-600">CI/CD</span></li>
-            <li><span className="text-gray-600">클라우드 아키텍처</span></li>
+            <li><span className="text-gray-600">크롤링</span></li>
+            <li><span className="text-gray-600">AI 업무 자동화</span></li>
           </ul>
         </div>
       </div>

--- a/components/curriculum/LecturesSidebar.tsx
+++ b/components/curriculum/LecturesSidebar.tsx
@@ -1,56 +1,123 @@
+"use client";
+
+import React, { useState } from "react";
+
+const sections = [
+  {
+    title: "오리지널",
+    titleClass: "text-blue-600",
+    items: ["바이브 빌더스"],
+  },
+  {
+    title: "바이브 코딩",
+    items: ["프롬프트 엔지니어링", "컨텍스트 엔지니어링", "AI 도구 활용"],
+  },
+  {
+    title: "앱/웹",
+    items: [
+      "앱 바이브 코딩 입문",
+      "웹 바이브 코딩 입문",
+      "앱 수익화",
+      "웹 수익화",
+    ],
+  },
+  {
+    title: "자동화",
+    items: [
+      "n8n",
+      "Make",
+      "PyTorch",
+      "크롤링",
+      "AI 업무 자동화",
+    ],
+  },
+];
+
+function SectionToggle({
+  title,
+  titleClass,
+  items,
+  open,
+  onClick,
+}: {
+  title: string;
+  titleClass?: string;
+  items: string[];
+  open: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <div className="mb-8">
+      <div
+        className="py-2 flex items-center cursor-pointer select-none"
+        onClick={onClick}
+      >
+        <span
+          className={`text-lg font-semibold ${titleClass ? titleClass : ""}`}
+        >
+          {title}
+        </span>
+        <span className="ml-2 text-gray-400">
+          {open ? (
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24">
+              <path
+                d="M6 15l6-6 6 6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          ) : (
+            <svg width="16" height="16" fill="none" viewBox="0 0 24 24">
+              <path
+                d="M18 9l-6 6-6-6"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          )}
+        </span>
+      </div>
+      {open && (
+        <ul className="mt-2 space-y-2 pl-4">
+          {items.map((item) => (
+            <li key={item}>
+              <span className="text-gray-600">{item}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 export default function LecturesSidebar() {
+  const [openSections, setOpenSections] = useState(
+    sections.map(() => true)
+  );
+
+  const handleToggle = (idx: number) => {
+    setOpenSections((prev) =>
+      prev.map((open, i) => (i === idx ? !open : open))
+    );
+  };
 
   return (
     <div className="w-64 bg-white border-r border-gray-200 min-h-screen">
       <div className="p-6">
-        {/* 오리지널 섹션 */}
-        <div className="mb-8">
-          <div className="py-2">
-            <h3 className="text-lg font-semibold text-blue-600">오리지널</h3>
-          </div>
-          <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">바이브 빌더스</span></li>
-          </ul>
-        </div>
-
-        {/* 바이브 코딩 섹션 */}
-        <div className="mb-8">
-          <div className="py-2">
-            <h3 className="text-lg font-semibold">바이브 코딩</h3>
-          </div>
-          <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">프롬프트 엔지니어링</span></li>
-            <li><span className="text-gray-600">컨텍스트 엔지니어링</span></li>
-            <li><span className="text-gray-600">AI 도구 활용</span></li>
-          </ul>
-        </div>
-
-        {/* 앱/웹 섹션 */}
-        <div className="mb-8">
-          <div className="py-2">
-            <h3 className="text-lg font-semibold">앱/웹</h3>
-          </div>
-          <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">앱 바이브 코딩 입문</span></li>
-            <li><span className="text-gray-600">웹 바이브 코딩 입문</span></li>
-            <li><span className="text-gray-600">앱 수익화</span></li>
-            <li><span className="text-gray-600">웹 수익화</span></li>
-          </ul>
-        </div>
-
-        {/* 자동화 섹션 */}
-        <div className="mb-8">
-          <div className="py-2">
-            <h3 className="text-lg font-semibold">자동화</h3>
-          </div>
-          <ul className="mt-2 space-y-2 pl-4">
-            <li><span className="text-gray-600">n8n</span></li>
-            <li><span className="text-gray-600">Make</span></li>
-            <li><span className="text-gray-600">PyTorch</span></li>
-            <li><span className="text-gray-600">크롤링</span></li>
-            <li><span className="text-gray-600">AI 업무 자동화</span></li>
-          </ul>
-        </div>
+        {sections.map((section, idx) => (
+          <SectionToggle
+            key={section.title}
+            title={section.title}
+            titleClass={section.titleClass}
+            items={section.items}
+            open={openSections[idx]}
+            onClick={() => handleToggle(idx)}
+          />
+        ))}
       </div>
     </div>
   );

--- a/components/curriculum/LecturesSidebar.tsx
+++ b/components/curriculum/LecturesSidebar.tsx
@@ -5,7 +5,6 @@ import React, { useState } from "react";
 const sections = [
   {
     title: "오리지널",
-    titleClass: "text-blue-600",
     items: ["바이브 빌더스"],
   },
   {
@@ -35,68 +34,67 @@ const sections = [
 
 function SectionToggle({
   title,
-  titleClass,
   items,
   open,
   onClick,
 }: {
   title: string;
-  titleClass?: string;
   items: string[];
   open: boolean;
   onClick: () => void;
 }) {
   return (
-    <div className="mb-8">
-      <div
-        className="py-2 flex items-center cursor-pointer select-none"
+    <div className="border-b border-gray-100 last:border-b-0">
+      <button
+        className="w-full flex items-center justify-between py-4 px-0 text-left focus:outline-none group"
         onClick={onClick}
+        aria-expanded={open}
       >
-        <span
-          className={`text-lg font-semibold ${titleClass ? titleClass : ""}`}
-        >
+        <span className={`text-lg font-medium transition-colors ${
+          open ? "text-blue-600" : "text-gray-800"
+        }`}>
           {title}
         </span>
-        <span className="ml-2 text-gray-400">
-          {open ? (
-            <svg width="16" height="16" fill="none" viewBox="0 0 24 24">
-              <path
-                d="M6 15l6-6 6 6"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          ) : (
-            <svg width="16" height="16" fill="none" viewBox="0 0 24 24">
-              <path
-                d="M18 9l-6 6-6-6"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-          )}
+        <span className="text-gray-400 group-hover:text-gray-600 transition-colors">
+          <svg
+            width="20"
+            height="20"
+            fill="none"
+            viewBox="0 0 24 24"
+            className={`transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+          >
+            <path
+              d="M6 9l6 6 6-6"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
         </span>
-      </div>
-      {open && (
-        <ul className="mt-2 space-y-2 pl-4">
+      </button>
+      <div
+        className={`overflow-hidden transition-all duration-300 ease-in-out ${
+          open ? "max-h-96 pb-4" : "max-h-0"
+        }`}
+      >
+        <ul className="space-y-2 pl-0">
           {items.map((item) => (
             <li key={item}>
-              <span className="text-gray-600">{item}</span>
+              <span className="block text-gray-600 text-base py-2 hover:text-gray-800 transition-colors duration-150 cursor-pointer">
+                {item}
+              </span>
             </li>
           ))}
         </ul>
-      )}
+      </div>
     </div>
   );
 }
 
 export default function LecturesSidebar() {
   const [openSections, setOpenSections] = useState(
-    sections.map(() => true)
+    sections.map((_, idx) => idx === 1) // 두 번째 섹션만 열어둠 (이미지와 같이)
   );
 
   const handleToggle = (idx: number) => {
@@ -106,19 +104,36 @@ export default function LecturesSidebar() {
   };
 
   return (
-    <div className="w-64 bg-white border-r border-gray-200 min-h-screen">
-      <div className="p-6">
-        {sections.map((section, idx) => (
-          <SectionToggle
-            key={section.title}
-            title={section.title}
-            titleClass={section.titleClass}
-            items={section.items}
-            open={openSections[idx]}
-            onClick={() => handleToggle(idx)}
-          />
-        ))}
+    <aside
+      className="
+        w-full
+        md:w-64
+        bg-white
+        min-h-screen
+        fixed
+        md:static
+        z-20
+        top-0
+        left-0
+        transition-all
+        duration-300
+        flex-shrink-0
+      "
+      style={{ maxWidth: "100vw" }}
+    >
+      <div className="px-6 py-8">
+        <div className="space-y-0">
+          {sections.map((section, idx) => (
+            <SectionToggle
+              key={section.title}
+              title={section.title}
+              items={section.items}
+              open={openSections[idx]}
+              onClick={() => handleToggle(idx)}
+            />
+          ))}
+        </div>
       </div>
-    </div>
+    </aside>
   );
 }

--- a/components/curriculum/LecturesSidebar.tsx
+++ b/components/curriculum/LecturesSidebar.tsx
@@ -104,23 +104,7 @@ export default function LecturesSidebar() {
   };
 
   return (
-    <aside
-      className="
-        w-full
-        md:w-64
-        bg-white
-        min-h-screen
-        fixed
-        md:static
-        z-20
-        top-0
-        left-0
-        transition-all
-        duration-300
-        flex-shrink-0
-      "
-      style={{ maxWidth: "100vw" }}
-    >
+    <aside className="w-full bg-white border-r border-gray-100 min-h-screen">
       <div className="px-6 py-8">
         <div className="space-y-0">
           {sections.map((section, idx) => (


### PR DESCRIPTION
## #️⃣연관된 이슈

> VZOG-37

## 📝작업 내용

> 카테고리 토글 추가 및 ui 수정하였습니다.
> 커리큘럼 페이지 전체적인 레이아웃 및 ui 수정하였습니다.

### 스크린샷 (선택)
<img width="1692" height="858" alt="스크린샷 2025-08-04 오후 3 47 58" src="https://github.com/user-attachments/assets/95fa1169-f6d7-4f30-9b65-8f4ea30738be" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사이드바가 동적으로 확장/축소되는 인터랙티브 기능이 추가되었습니다. 각 섹션을 클릭하여 펼치거나 닫을 수 있습니다.

* **Style**
  * 메인 컨테이너와 그리드, 카드, 히어로 섹션 등 전체 레이아웃과 배경, 여백, 타이포그래피, 버튼 스타일이 개선되었습니다.
  * 강의 카드에 호버 효과와 심플한 뱃지 제거, 강사명 및 카테고리 표시 등이 추가되었습니다.
  * 히어로 섹션의 이미지와 CTA(콜투액션) 영역이 새롭게 디자인되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->