### PR TITLE
demolearn-44[Feat & style]: 내 강의 목록 마크업 추가 및 UI 수정

### DIFF
--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,65 +1,21 @@
 "use client";
-
 import { useState } from "react";
 import MyPageSidebar from "@/components/mypage/MyPageSidebar";
 import MyPageDashboard from "@/components/mypage/MyPageDashboard";
 import MyPageProfile from "@/components/mypage/MyPageProfile";
-import { User, LayoutGrid } from "lucide-react";
-
 export default function MyPage() {
   const [activeTab, setActiveTab] = useState<"dashboard" | "profile">("dashboard");
-
-  const tabs = [
-    {
-      id: "dashboard",
-      label: "내 강의실",
-      icon: <LayoutGrid className="w-4 h-4 mr-2" />,
-    },
-    {
-      id: "profile",
-      label: "프로필",
-      icon: <User className="w-4 h-4 mr-2" />,
-    },
-  ];
-
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-6 lg:py-8">
         <div className="flex flex-col lg:flex-row gap-4 lg:gap-6">
           {/* 좌측 사이드바 - 모바일에서는 상단에 위치 */}
           <aside className="w-full lg:w-64 flex-shrink-0">
-            <MyPageSidebar />
+            <MyPageSidebar activeTab={activeTab} onTabChange={setActiveTab} />
           </aside>
 
           {/* 메인 컨텐츠 */}
           <main className="flex-1">
-            {/* 탭 네비게이션 */}
-            <div className="mb-6" role="tablist">
-              <div className="flex gap-2 px-4 pt-4">
-                {tabs.map((tab) => (
-                  <button
-                    key={tab.id}
-                    role="tab"
-                    aria-selected={activeTab === tab.id}
-                    aria-controls={`${tab.id}-panel`}
-                    id={`${tab.id}-tab`}
-                    onClick={() => setActiveTab(tab.id as "dashboard" | "profile")}
-                    className={`flex items-center gap-1 px-4 py-2 rounded-full font-medium text-sm transition-colors duration-150
-                      ${
-                        activeTab === tab.id
-                          ? "bg-blue-50 text-blue-600 shadow border border-blue-200"
-                          : "bg-gray-100 text-gray-500 hover:bg-blue-50 hover:text-blue-600"
-                      }
-                    `}
-                    style={{ minWidth: 110 }}
-                  >
-                    {tab.icon}
-                    {tab.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-
             {/* 탭 컨텐츠 */}
             <div
               role="tabpanel"

--- a/components/mypage/MyPageDashboard.tsx
+++ b/components/mypage/MyPageDashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Flame, BarChart3, BookOpen, FileText, Users, ClipboardList } from "lucide-react";
+import { Flame, BookOpen, Users, ClipboardList } from "lucide-react";
 
 // 더미 데이터
 const dummyLearningData = {

--- a/components/mypage/MyPageSidebar.tsx
+++ b/components/mypage/MyPageSidebar.tsx
@@ -1,5 +1,4 @@
 "use client";
-
 import { 
   User, 
   BookOpen, 
@@ -10,7 +9,8 @@ import {
   ShoppingCart,
   HelpCircle,
   Settings,
-  ChevronRight
+  ChevronRight,
+  LayoutGrid
 } from "lucide-react";
 import Image from "next/image";
 
@@ -20,13 +20,17 @@ interface MenuItem {
   href?: string;
   count?: number;
 }
-
 interface MenuSection {
   title: string;
   items: MenuItem[];
 }
 
-export default function MyPageSidebar() {
+interface MyPageSidebarProps {
+  activeTab?: "dashboard" | "profile";
+  onTabChange?: (tab: "dashboard" | "profile") => void;
+}
+
+export default function MyPageSidebar({ activeTab, onTabChange }: MyPageSidebarProps) {
   // 임시 사용자 데이터
   const userData = {
     name: "고성현",
@@ -37,7 +41,6 @@ export default function MyPageSidebar() {
     points: 0,
     credits: 0,
   };
-
   const menuSections: MenuSection[] = [
     {
       title: "강의 관련",
@@ -64,7 +67,6 @@ export default function MyPageSidebar() {
       ],
     },
   ];
-
   return (
     <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
       {/* 프로필 섹션 */}
@@ -92,7 +94,6 @@ export default function MyPageSidebar() {
         <h2 className="font-bold text-base sm:text-lg">{userData.name}</h2>
         <p className="text-xs sm:text-sm text-gray-500">{userData.levelTitle} <span className="text-blue-600">{userData.level}</span></p>
       </div>
-
       {/* 통계 섹션 */}
       <div className="grid grid-cols-3 gap-2 mb-4 sm:mb-6 pb-4 sm:pb-6 border-b">
         <div className="text-center">
@@ -108,6 +109,36 @@ export default function MyPageSidebar() {
           <p className="font-semibold text-sm sm:text-base text-blue-600">{userData.points}원</p>
         </div>
       </div>
+
+      {/* 탭 네비게이션 */}
+      {onTabChange && (
+        <div className="mb-4 sm:mb-6 pb-4 sm:pb-6 border-b">
+          <div className="space-y-2">
+            <button
+              onClick={() => onTabChange("dashboard")}
+              className={`w-full flex items-center px-3 py-3 rounded-lg text-sm font-medium transition-colors ${
+                activeTab === "dashboard"
+                  ? "bg-blue-50 text-blue-600 border border-blue-200"
+                  : "text-gray-700 hover:bg-gray-50"
+              }`}
+            >
+              <LayoutGrid className="w-4 h-4 mr-3" />
+              내 강의실
+            </button>
+            <button
+              onClick={() => onTabChange("profile")}
+              className={`w-full flex items-center px-3 py-3 rounded-lg text-sm font-medium transition-colors ${
+                activeTab === "profile"
+                  ? "bg-blue-50 text-blue-600 border border-blue-200"
+                  : "text-gray-700 hover:bg-gray-50"
+              }`}
+            >
+              <User className="w-4 h-4 mr-3" />
+              프로필
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* 메뉴 섹션 - 모바일에서는 숨김, 태블릿부터 표시 */}
       <nav className="hidden lg:block">


### PR DESCRIPTION
## #️⃣연관된 이슈

> VZOG-44

## 📝작업 내용

> 마이페이지에 내 강의 목록 마크업 추가 및 UI 수정하였습니다.
> 내 강의실과 프로필 버튼 UI 수정하였습니다.

### 스크린샷 (선택)
[내 강의 목록 UI]
https://github.com/user-attachments/assets/8ba68e37-098a-41ed-81d2-6f461f58339b

[내 강의실 & 프로필 버튼 UI]
https://github.com/user-attachments/assets/a4eb200f-97b5-4f00-85de-0f60c78ff7f8

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지 대시보드에 "강의", "과제 관리", "조편성" 탭 인터페이스가 추가되었습니다.
  * 각 탭별로 아이콘과 안내 메시지가 표시됩니다.
  * 사이드바에서 "내 강의실"과 "프로필" 탭 전환이 가능해졌습니다.

* **스타일**
  * 탭 버튼 및 빈 상태 메시지 디자인이 개선되었습니다.

* **리팩터**
  * 대시보드와 사이드바의 탭 관리 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->